### PR TITLE
feat(frontend): Cria seção para detalhes no PCPT

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import '@mantine/core/styles.css';
 import '@mantine/spotlight/styles.css';
+import '@mantine/notifications/styles.css';
 
 import { ColorSchemeScript, Flex, mantineHtmlProps } from '@mantine/core';
 

--- a/frontend/src/app/patients/[patientId]/procedures/[procedureId]/loading.tsx
+++ b/frontend/src/app/patients/[patientId]/procedures/[procedureId]/loading.tsx
@@ -1,0 +1,12 @@
+import { Box, Loader, Stack } from '@mantine/core';
+
+export default function LoadingProcedurePage() {
+  return (
+    <Box style={{ height: '100vh' }}>
+      <Stack align="center" mt={100} style={{ height: '100%' }}>
+        <Loader size="lg" />
+        Carregando Procedimento
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/src/app/patients/[patientId]/procedures/[procedureId]/page.tsx
+++ b/frontend/src/app/patients/[patientId]/procedures/[procedureId]/page.tsx
@@ -1,6 +1,9 @@
 import { getQueryClient } from '@/app/get-query-client';
-import { getProcedureSupervisors } from '@/features/procedure/requests';
-import SupervisorSection from '@/features/procedure/ui/supervisor-section';
+import {
+  getDetails,
+  getProcedureSupervisors,
+} from '@/features/procedure/requests';
+import TreatmentPlanCreationProcedure from '@/features/procedure/ui/tpcp';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 
 interface ProcedureParams {
@@ -17,16 +20,22 @@ export default async function ProcedurePage({
 
   const queryClient = getQueryClient();
 
-  await queryClient.prefetchQuery({
-    queryKey: ['procedureSupervisors', procedureId],
-    queryFn: async () => getProcedureSupervisors(procedureId),
-  });
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: ['procedureSupervisors', procedureId],
+      queryFn: async () => getProcedureSupervisors(procedureId),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ['procedureDetails', procedureId],
+      queryFn: () => getDetails(procedureId),
+    }),
+  ]);
 
   return (
     <div style={{ padding: '24px' }}>
       <p>Página de um procedimento</p>
       <HydrationBoundary state={dehydrate(queryClient)}>
-        <SupervisorSection procedureId={procedureId} />
+        <TreatmentPlanCreationProcedure procedureId={procedureId} />
       </HydrationBoundary>
     </div>
   );

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { getQueryClient } from '@/app/get-query-client';
 import type * as React from 'react';
 import { MantineProvider, createTheme } from '@mantine/core';
+import { Notifications } from '@mantine/notifications';
 
 const theme = createTheme({
   fontFamily: 'Open Sans, sans-serif',
@@ -14,7 +15,10 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <MantineProvider theme={theme}>{children}</MantineProvider>
+      <MantineProvider theme={theme}>
+        <Notifications />
+        {children}
+      </MantineProvider>
     </QueryClientProvider>
   );
 }

--- a/frontend/src/features/procedure/models.ts
+++ b/frontend/src/features/procedure/models.ts
@@ -16,3 +16,8 @@ export type Supervisor = {
 export type SupervisorAndReview = Supervisor & {
   lastReview: SupervisorReview;
 };
+
+export type ProcedureDetail = {
+  notes: string;
+  diagnostic?: string;
+};

--- a/frontend/src/features/procedure/requests.ts
+++ b/frontend/src/features/procedure/requests.ts
@@ -48,8 +48,7 @@ export async function getAvailableSupervisors(): Promise<Supervisor[]> {
 }
 
 let Superdata: ProcedureDetail = {
-  notes: 'something',
-  diagnostic: 'opaopaopa',
+  notes: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`,
 };
 
 export async function getDetails(

--- a/frontend/src/features/procedure/requests.ts
+++ b/frontend/src/features/procedure/requests.ts
@@ -3,7 +3,7 @@ import {
   supervisorsAndReviews,
   setSupervisorsAndReviews,
 } from '@/mocks/supervisor';
-import { Supervisor, SupervisorAndReview } from './models';
+import { ProcedureDetail, Supervisor, SupervisorAndReview } from './models';
 
 export async function saveSupervisors(
   procedureId: string,
@@ -45,4 +45,25 @@ export async function getProcedureSupervisors(
 export async function getAvailableSupervisors(): Promise<Supervisor[]> {
   await new Promise((resolve) => setTimeout(resolve, 500));
   return supervisors;
+}
+
+let Superdata: ProcedureDetail = {
+  notes: 'something',
+  diagnostic: 'opaopaopa',
+};
+
+export async function getDetails(
+  procedureId: string,
+): Promise<ProcedureDetail> {
+  console.log('fething detail for procedureID: ', procedureId);
+  await new Promise((resolve) => setTimeout(resolve, 2500));
+  console.log(Superdata);
+  return Superdata;
+}
+
+export async function saveDetails(procedureId: string, data: ProcedureDetail) {
+  await new Promise((resolve) => setTimeout(resolve, 2500));
+  console.log('saving data', data, procedureId);
+  // throw new Error('error saving data');
+  Superdata = data;
 }

--- a/frontend/src/features/procedure/requests.ts
+++ b/frontend/src/features/procedure/requests.ts
@@ -55,14 +55,15 @@ export async function getDetails(
   procedureId: string,
 ): Promise<ProcedureDetail> {
   console.log('fething detail for procedureID: ', procedureId);
-  await new Promise((resolve) => setTimeout(resolve, 2500));
+  await new Promise((resolve) => setTimeout(resolve, 1000));
   console.log(Superdata);
   return Superdata;
 }
 
 export async function saveDetails(procedureId: string, data: ProcedureDetail) {
-  await new Promise((resolve) => setTimeout(resolve, 2500));
+  await new Promise((resolve) => setTimeout(resolve, 2000));
   console.log('saving data', data, procedureId);
   // throw new Error('error saving data');
   Superdata = data;
+  return Superdata;
 }

--- a/frontend/src/features/procedure/ui/detail-section.tsx
+++ b/frontend/src/features/procedure/ui/detail-section.tsx
@@ -11,10 +11,12 @@ import {
   Center,
   Loader,
   Flex,
+  ActionIcon,
 } from '@mantine/core';
 import { ProcedureDetail } from '../models';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { getDetails, saveDetails } from '../requests';
+import { IconEdit } from '@tabler/icons-react';
 
 const LABELS: Record<string, string> = {
   diagnostic: 'Diagnóstico',
@@ -41,21 +43,21 @@ export default function DetailSection({ procedureId }: DetailSectionProps) {
             Detalhes
           </Text>
           {!editing && (
-            <Button
-              size="xs"
-              variant="default"
-              onClick={() => setEditing(true)}
+            <ActionIcon
+              variant="subtle"
+              color="gray"
               disabled={isLoading}
+              onClick={() => setEditing(true)}
             >
-              Editar
-            </Button>
+              <IconEdit size={16} />
+            </ActionIcon>
           )}
         </Group>
       </Card.Section>
 
       <Divider my="none" />
 
-      <Card.Section inheritPadding p="md">
+      <Card.Section inheritPadding px="md" py="sm">
         {isLoading || !data ? (
           <Center py="md">
             <Loader size="sm" />
@@ -113,29 +115,40 @@ function DetailSectionContent({
 
   return (
     <>
-      {Object.entries(values).map(([key, value]) => (
-        <div key={key}>
-          <Text size="sm" fw={500}>
-            {LABELS[key]}
-          </Text>
-          {!editing ? (
-            <Text size="sm" c={value ? 'black' : 'dimmed'}>
-              {value || 'Nenhum valor definido'}
+      <Flex direction="column" gap="sm">
+        {Object.entries(values).map(([key, value]) => (
+          <div key={key}>
+            <Text size="sm" fw={600}>
+              {LABELS[key]}
             </Text>
-          ) : (
-            <Textarea
-              value={value}
-              onChange={(e) => handleChange(key, e.currentTarget.value)}
-              autosize
-              minRows={2}
-            />
-          )}
-        </div>
-      ))}
+            {!editing ? (
+              <Text
+                size="sm"
+                c={value ? 'black' : 'dimmed'}
+                style={{ whiteSpace: 'pre-line', textAlign: 'justify' }}
+              >
+                {value || 'Nenhum valor definido'}
+              </Text>
+            ) : (
+              <Textarea
+                value={value}
+                onChange={(e) => handleChange(key, e.currentTarget.value)}
+                autosize
+                minRows={2}
+              />
+            )}
+          </div>
+        ))}
+      </Flex>
       {editing && (
-        <Flex justify="space-between" align="center" direction="row-reverse">
-          <Group mt="sm">
-            <Button variant="default" onClick={handleCancel}>
+        <Flex
+          justify="space-between"
+          align="center"
+          direction="row-reverse"
+          mt="sm"
+        >
+          <Group gap="xs">
+            <Button variant="default" fw="normal" onClick={handleCancel}>
               Cancelar
             </Button>
             <Button onClick={handleSave} loading={mutation.isPending}>
@@ -143,7 +156,7 @@ function DetailSectionContent({
             </Button>
           </Group>
           {mutation.isError && (
-            <Text c="red" size="sm">
+            <Text c="red" size="sm" fw={600}>
               Erro ao salvar dados. Tente novamente mais tarde.
             </Text>
           )}

--- a/frontend/src/features/procedure/ui/detail-section.tsx
+++ b/frontend/src/features/procedure/ui/detail-section.tsx
@@ -13,10 +13,11 @@ import {
   Flex,
   ActionIcon,
 } from '@mantine/core';
-import { ProcedureDetail } from '../models';
+import { notifications } from '@mantine/notifications';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { IconEdit, IconExclamationCircle } from '@tabler/icons-react';
+import { ProcedureDetail } from '../models';
 import { getDetails, saveDetails } from '../requests';
-import { IconEdit } from '@tabler/icons-react';
 
 const LABELS: Record<string, string> = {
   diagnostic: 'Diagnóstico',
@@ -107,6 +108,15 @@ function DetailSectionContent({
       setValues({});
       setEditing(false);
     },
+    onError(error) {
+      notifications.show({
+        title: 'Não foi possível salvar os dados',
+        message: `Um erro inesperado aconteceu e não foi possível salvar suas alterações nos detalhes. Tente novamente mais tarde. ${error}`,
+        color: 'red',
+        icon: <IconExclamationCircle />,
+        autoClose: 5000,
+      });
+    },
   });
 
   async function handleSave() {
@@ -141,7 +151,6 @@ function DetailSectionContent({
                 onChange={(e) => handleChange(key, e.currentTarget.value)}
                 autosize
                 minRows={2}
-                error={mutation.isError}
               />
             )}
           </div>
@@ -162,11 +171,6 @@ function DetailSectionContent({
               Salvar
             </Button>
           </Group>
-          {mutation.isError && (
-            <Text c="red" size="sm" fw={600}>
-              Erro ao salvar dados. Tente novamente mais tarde.
-            </Text>
-          )}
         </Flex>
       )}
     </>

--- a/frontend/src/features/procedure/ui/detail-section.tsx
+++ b/frontend/src/features/procedure/ui/detail-section.tsx
@@ -141,6 +141,7 @@ function DetailSectionContent({
                 onChange={(e) => handleChange(key, e.currentTarget.value)}
                 autosize
                 minRows={2}
+                error={mutation.isError}
               />
             )}
           </div>

--- a/frontend/src/features/procedure/ui/detail-section.tsx
+++ b/frontend/src/features/procedure/ui/detail-section.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Text,
+  Textarea,
+  Button,
+  Group,
+  Card,
+  Divider,
+  Center,
+  Loader,
+  Flex,
+} from '@mantine/core';
+import { ProcedureDetail } from '../models';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { getDetails, saveDetails } from '../requests';
+
+const LABELS: Record<string, string> = {
+  diagnostic: 'Diagnóstico',
+  notes: 'Observações',
+};
+
+interface DetailSectionProps {
+  procedureId: string;
+}
+
+export default function DetailSection({ procedureId }: DetailSectionProps) {
+  const [editing, setEditing] = useState(false);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['procedureDetails', procedureId],
+    queryFn: () => getDetails(procedureId),
+  });
+
+  return (
+    <Card withBorder shadow="sm" radius="md" px="sm">
+      <Card.Section inheritPadding py="xs">
+        <Group justify="space-between">
+          <Text fw={700} size="lg">
+            Detalhes
+          </Text>
+          {!editing && (
+            <Button
+              size="xs"
+              variant="default"
+              onClick={() => setEditing(true)}
+              disabled={isLoading}
+            >
+              Editar
+            </Button>
+          )}
+        </Group>
+      </Card.Section>
+
+      <Divider my="none" />
+
+      <Card.Section inheritPadding p="md">
+        {isLoading || !data ? (
+          <Center py="md">
+            <Loader size="sm" />
+          </Center>
+        ) : (
+          <DetailSectionContent
+            data={data}
+            editing={editing}
+            setEditing={setEditing}
+            procedureId={procedureId}
+          />
+        )}
+      </Card.Section>
+    </Card>
+  );
+}
+
+interface DetailSectionContentProps {
+  data: ProcedureDetail;
+  editing: boolean;
+  setEditing: (value: boolean) => void;
+  procedureId: string;
+}
+
+function DetailSectionContent({
+  data,
+  editing,
+  setEditing,
+  procedureId,
+}: DetailSectionContentProps) {
+  const originalData = { ...data };
+
+  const [values, setValues] = useState<ProcedureDetail>(data);
+
+  function handleChange(key: string, value: string) {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  }
+
+  const mutation = useMutation({
+    mutationFn: (values: ProcedureDetail) => saveDetails(procedureId, values),
+    onSuccess: () => {
+      setEditing(false);
+    },
+  });
+
+  async function handleSave() {
+    await mutation.mutateAsync(values);
+  }
+
+  function handleCancel() {
+    setValues(originalData);
+    setEditing(false);
+    mutation.reset();
+  }
+
+  return (
+    <>
+      {Object.entries(values).map(([key, value]) => (
+        <div key={key}>
+          <Text size="sm" fw={500}>
+            {LABELS[key]}
+          </Text>
+          {!editing ? (
+            <Text size="sm" c={value ? 'black' : 'dimmed'}>
+              {value || 'Nenhum valor definido'}
+            </Text>
+          ) : (
+            <Textarea
+              value={value}
+              onChange={(e) => handleChange(key, e.currentTarget.value)}
+              autosize
+              minRows={2}
+            />
+          )}
+        </div>
+      ))}
+      {editing && (
+        <Flex justify="space-between" align="center" direction="row-reverse">
+          <Group mt="sm">
+            <Button variant="default" onClick={handleCancel}>
+              Cancelar
+            </Button>
+            <Button onClick={handleSave} loading={mutation.isPending}>
+              Salvar
+            </Button>
+          </Group>
+          {mutation.isError && (
+            <Text c="red" size="sm">
+              Erro ao salvar dados. Tente novamente mais tarde.
+            </Text>
+          )}
+        </Flex>
+      )}
+    </>
+  );
+}

--- a/frontend/src/features/procedure/ui/tpcp.tsx
+++ b/frontend/src/features/procedure/ui/tpcp.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import SupervisorSection from './supervisor-section';
+import DetailSection from './detail-section';
+
+interface TreatmentPlanCreationProcedureProps {
+  procedureId: string;
+}
+
+export default function TreatmentPlanCreationProcedure({
+  procedureId,
+}: TreatmentPlanCreationProcedureProps) {
+  return (
+    <div>
+      <SupervisorSection procedureId={procedureId} />
+      <DetailSection procedureId={procedureId} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Resumo
Criado componente para campo de observação do Procedimento de Criação do Plano de Tratamento (PCPT). O usuário pode clicar no botão de editar para alterar o dado e depois salvá-lo.

## Informações adicionais
### Sobre o componente
O Componente tem três estados:
1. Em carregamento: Dados não foram carregados ainda. Mostra spinner
2. Modo leitura: Label e informações direto no HTML
3. Modo edição: Textareas com conteúdo para edição. Ao Clicar em salvar, as informações são atualizadas.
4. Modo edição com erro: Aparece uma mensagem

https://github.com/user-attachments/assets/cba0f6af-dfad-453f-8092-813ac10dcb83

>[!note]
> Para reproduzir o estado de erro, remova o comentário da linha 66 do arquivo `frontend/src/features/procedure/requests.ts`. 
>
> Obs: isso será removido na integração com o backend

### Sobre a implementação
Estou adotando uma abordagem modular para os componentes da página do Procedimento. Ou seja, cada componente é responsável por fazer a requisição para os seus dados. Isso resulta em uma série de pequenas requisições que devem ser feitas para construir a página.

Lados negativos:
- Várias requisições são mais lentas (acredito que marginalmente), do que uma única requisição grande.

Lados positivos:
- Melhor separação entre componentes
- Endpoints mais claros e simples

Além disso, as várias requisições podem ser feitas em paralelo. No nosso caso, acho que é vantajoso fazer dessa forma, especialmente porque essa página dos procedimentos deve ter um layout reutilizável. Também tem o fato de que não vai ser um tráfego de requisições muito pesado, então o lado negativo é menos impactante.

### Sobre a sincronização de dados com o backend
É importante que os componentes, ao serem alterados, mantenham sincronia com o backend, que será nossa **fonte de verdade**. Então, após fazer uma mutação (POST, PUT, DELETE) temos duas opções:

1. Invalidar a query GET principal dos dados, ou seja, fazer uma outra requisição para atualizar os valores da tela
2. Usar o dado da resposta do endpoint de mutação para atualizar o cache do frontend.

Nesse caso, eu usei o segundo. Logo, o backend precisa enviar os dados atualizados de volta depois que realizar a persistência.

## Task relacionada
<!-- Adicione link(s) para as tasks do Jira relacionadas a este PR -->
[PDS-117](https://rvaf.atlassian.net/browse/PDS-117)
