### PR TITLE
PDS-126: Feature: Configurando o ambiente de prod

### DIFF
--- a/server/src/main/resources/application-prod.properties
+++ b/server/src/main/resources/application-prod.properties
@@ -1,5 +1,2 @@
 spring.docker.compose.lifecycle-management=none
-spring.jpa.hibernate.ddl-auto=create
-spring.datasource.url=${SPRING_DATASOURCE_URL}
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.jpa.hibernate.ddl-auto=validate

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=odontolog
+spring.profiles.default=dev
+spring.config.import=optional:file:.env[.properties]


### PR DESCRIPTION
## Resumo
<!-- Inclua um resumo da alteração -->
Este pull request atualiza os arquivos de configuração da aplicação para melhorar o gerenciamento de ambientes e o manuseio do schema do banco de dados. As mudanças mais importantes estão agrupadas abaixo:

Gerenciamento de ambiente e configuração:

- Definido o perfil (profile) padrão do Spring para dev e habilitada a importação de variáveis de ambiente de um arquivo .env no application.properties para otimizar a configuração e o desenvolvimento local.

Gerenciamento do schema do banco de dados:

- Alterada a configuração ddl-auto do Hibernate de create para validate no application-prod.properties, garantindo que o ambiente de produção agora valide o schema em vez de recriá-lo na inicialização. Isso ajuda a prevenir a perda acidental de dados.

## Informações adicionais
<!-- Adicione detalhes adicionais que você acha importante -->
<!-- Adicione um print quando possível -->
<img width="875" height="681" alt="image" src="https://github.com/user-attachments/assets/2ee93781-6fd1-4c0e-b2df-5dd2c91bf978" />



## Task relacionada
<!-- Adicione link(s) para as tasks do Jira relacionadas a este PR -->
[PDS-126](https://rvaf.atlassian.net/browse/PDS-126)


[PDS-126]: https://rvaf.atlassian.net/browse/PDS-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ