### PR TITLE
feat(frontend): Criar modal de 'Requerimento de avaliação' para Plano de Tratamento

### DIFF
--- a/frontend/src/features/treatment-plan/ask-review-modal.tsx
+++ b/frontend/src/features/treatment-plan/ask-review-modal.tsx
@@ -1,0 +1,78 @@
+import {
+  Modal,
+  Group,
+  Text,
+  Stack,
+  Button,
+  Flex,
+  Textarea,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+
+interface RequestReviewModalProps {
+  opened: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export default function RequestReviewModal(props: RequestReviewModalProps) {
+  return (
+    <>
+      <Modal.Root opened={props.opened} onClose={props.close} size="lg">
+        <Modal.Overlay />
+        <Modal.Content>
+          <Modal.Header>
+            <Stack gap="0" style={{ flex: 1 }}>
+              <Group>
+                <Modal.Title fw="600">Requerimento de avaliação</Modal.Title>
+                <Modal.CloseButton />
+              </Group>
+              <Text size="sm" c="dimmed">
+                Lembre-se de inserir informações adicionais relevantes para a
+                avaliação caso necessário.
+              </Text>
+            </Stack>
+          </Modal.Header>
+          <Modal.Body>
+            <RequestReviewModalBody {...props} />
+          </Modal.Body>
+        </Modal.Content>
+      </Modal.Root>
+    </>
+  );
+}
+
+function RequestReviewModalBody({ close }: RequestReviewModalProps) {
+  const form = useForm({
+    mode: 'uncontrolled',
+    initialValues: {
+      note: '',
+    },
+  });
+
+  const handleSubmit = (values: typeof form.values) => {
+    console.log(values);
+  };
+
+  return (
+    <form onSubmit={form.onSubmit(handleSubmit)}>
+      <Stack>
+        <Textarea
+          label="Observações adicionais"
+          placeholder="Escreva aqui..."
+          autosize
+          minRows={5}
+          maxRows={8}
+          key={form.key('note')}
+          {...form.getInputProps('note')}
+        />
+      </Stack>
+      <Flex direction="row-reverse" gap="xs" ml="auto" mt="md">
+        <Button type="submit">Enviar</Button>
+        <Button variant="default" fw="normal" onClick={close}>
+          Cancelar
+        </Button>
+      </Flex>
+    </form>
+  );
+}

--- a/frontend/src/features/treatment-plan/header.tsx
+++ b/frontend/src/features/treatment-plan/header.tsx
@@ -17,6 +17,8 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { TreatmentPlan } from '@/shared/models';
 import ReviewMenu from './review-menu';
 import styles from './header.module.css';
+import { useDisclosure } from '@mantine/hooks';
+import RequestReviewModal from './ask-review-modal';
 
 interface TreatmentPlanHeaderProps {
   id: string;
@@ -41,7 +43,7 @@ interface TreatmentPlanHeaderContentProps {
 
 function TreatmentPlanHeaderContent(props: TreatmentPlanHeaderContentProps) {
   const { id, queryOptions } = props;
-
+  const [opened, { open, close }] = useDisclosure(false);
   const { data, isLoading } = useQuery({
     ...queryOptions,
     select: (data) => ({
@@ -64,7 +66,10 @@ function TreatmentPlanHeaderContent(props: TreatmentPlanHeaderContentProps) {
 
   const breadcrumbsData = [
     { title: 'Pacientes', href: '/patients' },
-    { title: `${data.patient.name}`, href: `/patients/${data.patient.id}/procedures` },
+    {
+      title: `${data.patient.name}`,
+      href: `/patients/${data.patient.id}/procedures`,
+    },
     { title: `Plano de tratamento #${id}` },
   ];
 
@@ -134,13 +139,17 @@ function TreatmentPlanHeaderContent(props: TreatmentPlanHeaderContentProps) {
           </Group>
         </Stack>
         {props.mode === 'edit' ? (
-          <Button
-            fw={500}
-            rightSection={<IconChevronDown />}
-            className={styles.button}
-          >
-            Enviar para validação
-          </Button>
+          <>
+            <Button
+              fw={500}
+              rightSection={<IconChevronDown />}
+              className={styles.button}
+              onClick={open}
+            >
+              Enviar para validação
+            </Button>
+            <RequestReviewModal close={close} open={open} opened={opened} />
+          </>
         ) : (
           <ReviewMenu buttonProps={{ className: styles.button }}>
             Revisar

--- a/frontend/src/features/treatment-plan/header.tsx
+++ b/frontend/src/features/treatment-plan/header.tsx
@@ -5,20 +5,26 @@ import {
   Badge,
   Breadcrumbs,
   Button,
+  Flex,
   Group,
   Skeleton,
   Stack,
   Text,
   Title,
+  Tooltip,
 } from '@mantine/core';
-import { IconChevronDown, IconSlash } from '@tabler/icons-react';
+import {
+  IconAlertTriangle,
+  IconChevronDown,
+  IconSlash,
+} from '@tabler/icons-react';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 import { TreatmentPlan } from '@/shared/models';
 import ReviewMenu from './review-menu';
 import styles from './header.module.css';
 import { useDisclosure } from '@mantine/hooks';
-import RequestReviewModal from './ask-review-modal';
+import RequestReviewModal from './request-review-modal';
 
 interface TreatmentPlanHeaderProps {
   id: string;
@@ -51,6 +57,7 @@ function TreatmentPlanHeaderContent(props: TreatmentPlanHeaderContentProps) {
       status: data.status,
       updatedAt: data.updatedAt,
       assignee: data.assignee,
+      reviews: data.reviews,
     }),
   });
 
@@ -139,17 +146,31 @@ function TreatmentPlanHeaderContent(props: TreatmentPlanHeaderContentProps) {
           </Group>
         </Stack>
         {props.mode === 'edit' ? (
-          <>
+          <Flex align="center" gap={8}>
+            {data.reviews.length === 0 ? (
+              <Tooltip
+                label="Escolha o(s) supervisor(es)"
+                color="red"
+                position='left'
+                withArrow
+                arrowSize={6}
+              >
+                <IconAlertTriangle color="red" size={20} />
+              </Tooltip>
+            ) : (
+              <></>
+            )}
             <Button
               fw={500}
               rightSection={<IconChevronDown />}
               className={styles.button}
               onClick={open}
+              disabled={data.reviews.length === 0}
             >
               Enviar para validação
             </Button>
-            <RequestReviewModal close={close} open={open} opened={opened} />
-          </>
+            <RequestReviewModal treatmentPlanId={id} close={close} open={open} opened={opened} />
+          </Flex>
         ) : (
           <ReviewMenu buttonProps={{ className: styles.button }}>
             Revisar

--- a/frontend/src/features/treatment-plan/requests.ts
+++ b/frontend/src/features/treatment-plan/requests.ts
@@ -85,3 +85,16 @@ export async function createTreatmentPlanProcedure(
 
   return { success: true };
 }
+
+export async function submitTreatmentPlanForReview(
+  treatmentPlanId: string,
+  note: string,
+) {
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  console.log(`Submitting treatment plan ${treatmentPlanId} for review`);
+
+  treatmentPlanMock.notes = note;
+  treatmentPlanMock.status = 'in_review';
+
+  return { success: true };
+}

--- a/frontend/src/features/treatment-plan/treatment-plan.tsx
+++ b/frontend/src/features/treatment-plan/treatment-plan.tsx
@@ -15,9 +15,7 @@ interface TreatmentPlanProps {
   treatmentPlanId: string;
 }
 
-export default function TreatmentPlan({
-  treatmentPlanId,
-}: TreatmentPlanProps) {
+export default function TreatmentPlan({ treatmentPlanId }: TreatmentPlanProps) {
   const options = getTratmentPlanOptions(treatmentPlanId);
 
   return (

--- a/frontend/src/mocks/treatment-plan.ts
+++ b/frontend/src/mocks/treatment-plan.ts
@@ -128,7 +128,7 @@ export const treatmentPlanMock: TreatmentPlan = {
   reviews,
   history,
   type: 'treatment_plan',
-  status: 'in_review',
+  status: 'draft',
   procedures,
 };
 


### PR DESCRIPTION
## Resumo
<!-- Inclua um resumo da alteração -->
As alterações adicionam um modal para envio de solicitações de revisão e melhoram o feedback do usuário quando os supervisores não são selecionados .

* Adicionado um componente `RequestReviewModal` que permite aos usuários enviar planos de tratamento para revisão com notas opcionais; o modal é acionado por um botão no cabeçalho, já adicionado em outra PR.
* O header do plano de tratamento foi atualizado para exibir um ícone de aviso e uma tooltip quando nenhum supervisor for selecionado e o botão "Enviar para validação" foi desativado até que os supervisores sejam selecionados. O botão agora abre o modal de revisão.
* Adicionada a função `submitTreatmentPlanForReview` ao `requests.ts`, que atualiza o status e as observações do plano de tratamento mockado, simulando o processo de envio da revisão.
* Modificados os dados do plano de tratamento simulado para começar com o status `draft` em vez de `in_review`, refletindo o novo fluxo de revisão.

## Informações adicionais
<!-- Adicione detalhes adicionais que você acha importante -->
<!-- Adicione um print quando possível -->
<img width="661" height="333" alt="image" src="https://github.com/user-attachments/assets/73791e8f-9f2b-4250-991c-028f655d2bf8" />
<img width="1188" height="134" alt="image" src="https://github.com/user-attachments/assets/b836a15a-0787-4b17-89c1-c3ca5dda530f" />


https://github.com/user-attachments/assets/07c6c499-6d7e-4125-a08f-ba1ba7271713


## Task relacionada
<!-- Adicione link(s) para as tasks do Jira relacionadas a este PR -->
[PDS-125](https://rvaf.atlassian.net/browse/PDS-125)


**Code style and minor improvements:**

* Refactored imports and props handling in the treatment plan header for clarity and maintainability. [[1]](diffhunk://#diff-79ebda6d431ee02dc32a8a20fa807cf29392e0ee23b60092d5e27e787e241263R8-R27) [[2]](diffhunk://#diff-79ebda6d431ee02dc32a8a20fa807cf29392e0ee23b60092d5e27e787e241263L44-R60) [[3]](diffhunk://#diff-79ebda6d431ee02dc32a8a20fa807cf29392e0ee23b60092d5e27e787e241263L67-R79) [[4]](diffhunk://#diff-cc6d07527f09e78de5ea09eec9ad9fe49059e830a0bd121332b25852313933fdL18-R18)