### PR TITLE
PDS-154 fix(backend): Corrigindo o retorno do endpoint /reviewables/me

### DIFF
--- a/server/src/main/java/br/ufal/ic/odontolog/api/ReviewableApi.java
+++ b/server/src/main/java/br/ufal/ic/odontolog/api/ReviewableApi.java
@@ -3,6 +3,7 @@ package br.ufal.ic.odontolog.api;
 import br.ufal.ic.odontolog.dtos.ActivityDTO;
 import br.ufal.ic.odontolog.dtos.ReviewableCurrentSupervisorFilterDTO;
 import br.ufal.ic.odontolog.dtos.ReviewableDTO;
+import br.ufal.ic.odontolog.dtos.ReviewableShortDTO;
 import br.ufal.ic.odontolog.dtos.ReviewersDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -30,7 +31,7 @@ public interface ReviewableApi {
         @ApiResponse(responseCode = "200", description = "Search completed successfully."),
         @ApiResponse(responseCode = "422", description = "Authenticated supervisor not found."),
       })
-  public ResponseEntity<PagedModel<ReviewableDTO>> getCurrentSupervisorReviewables(
+  public ResponseEntity<PagedModel<ReviewableShortDTO>> getCurrentSupervisorReviewables(
       @ParameterObject Pageable pageable,
       @ParameterObject ReviewableCurrentSupervisorFilterDTO filter,
       @Parameter(hidden = true) UserDetails currentUser);
@@ -39,18 +40,18 @@ public interface ReviewableApi {
       summary = "Add reviewers to a reviewable item",
       description =
           """
-      Adds one or more reviewers to the specified reviewable item.
+            Adds one or more reviewers to the specified reviewable item.
 
-      Preconditions:
+            Preconditions:
 
-      - The reviewable item must exist in the system.
-      - The reviewers to be added must exist in the system.
-      - The reviewers must not already be assigned to the reviewable item.
+            - The reviewable item must exist in the system.
+            - The reviewers to be added must exist in the system.
+            - The reviewers must not already be assigned to the reviewable item.
 
-      Postconditions:
+            Postconditions:
 
-      - The specified reviewers will be associated with the reviewable item.
-      """)
+            - The specified reviewers will be associated with the reviewable item.
+            """)
   @ApiResponses(
       value = {
         @ApiResponse(responseCode = "200", description = "Reviewers added successfully."),
@@ -63,18 +64,18 @@ public interface ReviewableApi {
       summary = "Remove reviewers from a reviewable item",
       description =
           """
-      Removes one or more reviewers from the specified reviewable item.
+            Removes one or more reviewers from the specified reviewable item.
 
-      Preconditions:
+            Preconditions:
 
-      - The reviewable item must exist in the system.
-      - The reviewers to be removed must exist in the system.
-      - The reviewers must be currently assigned to the reviewable item.
+            - The reviewable item must exist in the system.
+            - The reviewers to be removed must exist in the system.
+            - The reviewers must be currently assigned to the reviewable item.
 
-      Postconditions:
+            Postconditions:
 
-      - The specified reviewers will be disassociated from the reviewable item.
-      """)
+            - The specified reviewers will be disassociated from the reviewable item.
+            """)
   @ApiResponses(
       value = {
         @ApiResponse(responseCode = "200", description = "Reviewers removed successfully."),
@@ -87,17 +88,17 @@ public interface ReviewableApi {
       summary = "Update reviewers for a reviewable item",
       description =
           """
-      Updates the list of reviewers for the specified reviewable item.
+            Updates the list of reviewers for the specified reviewable item.
 
-      Preconditions:
+            Preconditions:
 
-      - The reviewable item must exist in the system.
-      - The new reviewers must exist in the system.
+            - The reviewable item must exist in the system.
+            - The new reviewers must exist in the system.
 
-      Postconditions:
+            Postconditions:
 
-      - The reviewable item's reviewers will be updated to match the provided list.
-      """)
+            - The reviewable item's reviewers will be updated to match the provided list.
+            """)
   @ApiResponses(
       value = {
         @ApiResponse(responseCode = "200", description = "Reviewers updated successfully."),
@@ -110,16 +111,16 @@ public interface ReviewableApi {
       summary = "Get the review history of a reviewable item",
       description =
           """
-      Retrieves the complete history of reviews and actions taken on the specified reviewable item.
+            Retrieves the complete history of reviews and actions taken on the specified reviewable item.
 
-      Preconditions:
+            Preconditions:
 
-      - The reviewable item must exist in the system.
+            - The reviewable item must exist in the system.
 
-      Postconditions:
+            Postconditions:
 
-      - A list of all activities related to the reviewable item will be returned.
-      """)
+            - A list of all activities related to the reviewable item will be returned.
+            """)
   @ApiResponses(
       value = {
         @ApiResponse(responseCode = "200", description = "History retrieved successfully."),

--- a/server/src/main/java/br/ufal/ic/odontolog/controllers/ReviewableController.java
+++ b/server/src/main/java/br/ufal/ic/odontolog/controllers/ReviewableController.java
@@ -23,7 +23,7 @@ public class ReviewableController implements ReviewableApi {
 
   @PreAuthorize("hasRole('SUPERVISOR')")
   @GetMapping("/me")
-  public ResponseEntity<PagedModel<ReviewableDTO>> getCurrentSupervisorReviewables(
+  public ResponseEntity<PagedModel<ReviewableShortDTO>> getCurrentSupervisorReviewables(
       Pageable pageable,
       ReviewableCurrentSupervisorFilterDTO filter,
       @AuthenticationPrincipal UserDetails currentUser) {

--- a/server/src/main/java/br/ufal/ic/odontolog/dtos/ProcedureShortDTO.java
+++ b/server/src/main/java/br/ufal/ic/odontolog/dtos/ProcedureShortDTO.java
@@ -6,13 +6,15 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ProcedureShortDTO {
+public class ProcedureShortDTO extends ReviewableShortDTO {
   private Long id;
   private ProcedureStatus status;
   private String name;

--- a/server/src/main/java/br/ufal/ic/odontolog/dtos/ReviewableShortDTO.java
+++ b/server/src/main/java/br/ufal/ic/odontolog/dtos/ReviewableShortDTO.java
@@ -1,0 +1,3 @@
+package br.ufal.ic.odontolog.dtos;
+
+public class ReviewableShortDTO {}

--- a/server/src/main/java/br/ufal/ic/odontolog/dtos/TreatmentPlanShortDTO.java
+++ b/server/src/main/java/br/ufal/ic/odontolog/dtos/TreatmentPlanShortDTO.java
@@ -7,13 +7,15 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.time.Instant;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 @JsonTypeName("TREATMENT_PLAN")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@type")
 @NoArgsConstructor
-public class TreatmentPlanShortDTO {
+public class TreatmentPlanShortDTO extends ReviewableShortDTO {
   private Long id;
   private TreatmentPlanStatus status;
   private User assignee;

--- a/server/src/main/java/br/ufal/ic/odontolog/mappers/ReviewableMapper.java
+++ b/server/src/main/java/br/ufal/ic/odontolog/mappers/ReviewableMapper.java
@@ -1,8 +1,11 @@
 package br.ufal.ic.odontolog.mappers;
 
 import br.ufal.ic.odontolog.dtos.ProcedureDTO;
+import br.ufal.ic.odontolog.dtos.ProcedureShortDTO;
 import br.ufal.ic.odontolog.dtos.ReviewableDTO;
+import br.ufal.ic.odontolog.dtos.ReviewableShortDTO;
 import br.ufal.ic.odontolog.dtos.TreatmentPlanDTO;
+import br.ufal.ic.odontolog.dtos.TreatmentPlanShortDTO;
 import br.ufal.ic.odontolog.models.Procedure;
 import br.ufal.ic.odontolog.models.Reviewable;
 import br.ufal.ic.odontolog.models.TreatmentPlan;
@@ -19,4 +22,8 @@ public interface ReviewableMapper {
   ReviewableDTO toDTO(Reviewable reviewable);
 
   List<ReviewableDTO> toDTOs(List<Reviewable> reviewables);
+
+  @SubclassMapping(source = TreatmentPlan.class, target = TreatmentPlanShortDTO.class)
+  @SubclassMapping(source = Procedure.class, target = ProcedureShortDTO.class)
+  ReviewableShortDTO toShortDTO(Reviewable reviewable);
 }

--- a/server/src/main/java/br/ufal/ic/odontolog/models/PreProcedure.java
+++ b/server/src/main/java/br/ufal/ic/odontolog/models/PreProcedure.java
@@ -14,5 +14,8 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @Table(name = "pre_procedures")
 public class PreProcedure extends Procedure {
-  //
+  @Override
+  public String getProcedureType() {
+    return "PRE_PROCEDURE";
+  }
 }

--- a/server/src/main/java/br/ufal/ic/odontolog/models/Procedure.java
+++ b/server/src/main/java/br/ufal/ic/odontolog/models/Procedure.java
@@ -48,4 +48,6 @@ public abstract class Procedure extends Reviewable {
   public void addTooth(String tooth) {
     this.teeth.add(tooth);
   }
+
+  public abstract String getProcedureType();
 }

--- a/server/src/main/java/br/ufal/ic/odontolog/models/TreatmentPlanProcedure.java
+++ b/server/src/main/java/br/ufal/ic/odontolog/models/TreatmentPlanProcedure.java
@@ -21,4 +21,9 @@ public class TreatmentPlanProcedure extends Procedure {
   @JoinColumn(name = "treatment_plan_id")
   @NotNull
   private TreatmentPlan treatmentPlan;
+
+  @Override
+  public String getProcedureType() {
+    return "TREATMENT_PLAN_PROCEDURE";
+  }
 }

--- a/server/src/main/java/br/ufal/ic/odontolog/services/ReviewableService.java
+++ b/server/src/main/java/br/ufal/ic/odontolog/services/ReviewableService.java
@@ -3,6 +3,7 @@ package br.ufal.ic.odontolog.services;
 import br.ufal.ic.odontolog.dtos.ActivityDTO;
 import br.ufal.ic.odontolog.dtos.ReviewableCurrentSupervisorFilterDTO;
 import br.ufal.ic.odontolog.dtos.ReviewableDTO;
+import br.ufal.ic.odontolog.dtos.ReviewableShortDTO;
 import br.ufal.ic.odontolog.dtos.ReviewersDTO;
 import br.ufal.ic.odontolog.enums.ActivityType;
 import br.ufal.ic.odontolog.exceptions.ResourceNotFoundException;
@@ -38,7 +39,7 @@ public class ReviewableService {
   private final ActivityMapper activityMapper;
 
   @Transactional(readOnly = true)
-  public Page<ReviewableDTO> findForCurrentSupervisor(
+  public Page<ReviewableShortDTO> findForCurrentSupervisor(
       Pageable pageable,
       UserDetails currentUserDetails,
       ReviewableCurrentSupervisorFilterDTO filter) {
@@ -61,7 +62,7 @@ public class ReviewableService {
     }
 
     Page<Reviewable> page = reviewableRepository.findAll(spec, pageable);
-    Page<ReviewableDTO> dtoPage = page.map(reviewableMapper::toDTO);
+    Page<ReviewableShortDTO> dtoPage = page.map(reviewableMapper::toShortDTO);
 
     return dtoPage;
   }

--- a/server/src/test/java/br/ufal/ic/odontolog/services/ReviewableServiceUnitTest.java
+++ b/server/src/test/java/br/ufal/ic/odontolog/services/ReviewableServiceUnitTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.*;
 
 import br.ufal.ic.odontolog.dtos.ActivityDTO;
 import br.ufal.ic.odontolog.dtos.ReviewableCurrentSupervisorFilterDTO;
-import br.ufal.ic.odontolog.dtos.ReviewableDTO;
+import br.ufal.ic.odontolog.dtos.ReviewableShortDTO;
 import br.ufal.ic.odontolog.exceptions.ResourceNotFoundException;
 import br.ufal.ic.odontolog.exceptions.UnprocessableRequestException;
 import br.ufal.ic.odontolog.mappers.ActivityMapper;
@@ -66,15 +66,14 @@ public class ReviewableServiceUnitTest {
     when(reviewableRepository.findAll(any(Specification.class), eq(pageable)))
         .thenReturn(mockPageOfReviewables);
 
-    ReviewableDTO reviewableDTO = new ReviewableDTO();
-    reviewableDTO.setId(reviewableEntity.getId());
-    when(reviewableMapper.toDTO(reviewableEntity)).thenReturn(reviewableDTO);
+    ReviewableShortDTO reviewableShortDTO = new ReviewableShortDTO();
+    when(reviewableMapper.toShortDTO(reviewableEntity)).thenReturn(reviewableShortDTO);
 
     ReviewableCurrentSupervisorFilterDTO filter = new ReviewableCurrentSupervisorFilterDTO();
 
     // Act
 
-    Page<ReviewableDTO> result =
+    Page<ReviewableShortDTO> result =
         reviewableService.findForCurrentSupervisor(pageable, mockUserDetails, filter);
 
     // Assert
@@ -82,7 +81,6 @@ public class ReviewableServiceUnitTest {
     assertThat(result).isNotNull();
     assertThat(result.getTotalElements()).isEqualTo(1);
     assertThat(result.getContent()).hasSize(1);
-    assertThat(result.getContent().get(0).getId()).isEqualTo(reviewableEntity.getId());
 
     verify(supervisorRepository, times(1)).findByEmail("testsupervisor@test.com");
     verify(reviewableRepository, times(1)).findAll(any(Specification.class), eq(pageable));


### PR DESCRIPTION
## Resumo
<!-- Inclua um resumo da alteração -->
Corrigi o endpoint do /reviewables/me para retornar o ReviewableShortDTO ao invés de ReviewableDTO

## Informações adicionais
<!-- Adicione detalhes adicionais que você acha importante -->
<!-- Adicione um print quando possível -->
Eu criei um novo DTO vazio chamado ReviewableShortDTO, e fiz os DTOs ProcedureShortDTO e TreatmentPlanShortDTO extenderem desse novo DTO, para fazer um Union entre eles.

Adicionei um novo método em ReviewableMapper chamado toShortDTO que mapeia para ReviewableShortDTO (ProcedureShortDTO ou TreatmentPlanShortDTO, a depender do tipo).

Troquei o retorno do endpoint e do serviço para ReviewableShortDTO.

Adicionei uma correção referente ao retorno do tipo do Procedure, adicionando um método abstrato na classe do Procedure, `getProcedureType`, e implementando no PreProcedure e TreatmentPlanProcedure para eles retornarem os valores esperados no DTO.

## Task relacionada
<!-- Adicione link(s) para as tasks do Jira relacionadas a este PR -->
[PDS-154](https://rvaf.atlassian.net/browse/PDS-154)
