### PR TITLE
feat(frontend): Ajustar páginas com sessões de detalhes para versão mobile

### DIFF
--- a/frontend/src/app/(main)/patients/[patientId]/(dental-record)/treatments/page.tsx
+++ b/frontend/src/app/(main)/patients/[patientId]/(dental-record)/treatments/page.tsx
@@ -20,7 +20,7 @@ export default async function PatientTreatmentPlansPage({
         <TreatmentPlansSection patientId={patientId} />
       </Box>
 
-      <Box flex="1" h="100%">
+      <Box flex="1" h="100%" visibleFrom='md'>
         <TreatmentPlanDetailSection />
       </Box>
     </Group>

--- a/frontend/src/app/(main)/patients/[patientId]/(dental-record)/treatments/page.tsx
+++ b/frontend/src/app/(main)/patients/[patientId]/(dental-record)/treatments/page.tsx
@@ -15,7 +15,7 @@ export default async function PatientTreatmentPlansPage({
   const { patientId } = await params;
 
   return (
-    <Group align="flex-start" py="md" px="lg" h="100%">
+    <Group align="flex-start" py="md" px="lg" h="100%" wrap="nowrap">
       <Box flex="1" h="100%">
         <TreatmentPlansSection patientId={patientId} />
       </Box>

--- a/frontend/src/app/(main)/patients/[patientId]/(dental-record)/treatments/page.tsx
+++ b/frontend/src/app/(main)/patients/[patientId]/(dental-record)/treatments/page.tsx
@@ -20,7 +20,7 @@ export default async function PatientTreatmentPlansPage({
         <TreatmentPlansSection patientId={patientId} />
       </Box>
 
-      <Box flex="1" h="100%" visibleFrom='md'>
+      <Box flex="1" h="100%" visibleFrom="md">
         <TreatmentPlanDetailSection />
       </Box>
     </Group>

--- a/frontend/src/app/(main)/validations/page.tsx
+++ b/frontend/src/app/(main)/validations/page.tsx
@@ -17,7 +17,7 @@ export default function ProcedureValidationPage() {
         </Box>
 
         {/* TODO: Colocar o DetailSection do Procedure */}
-        <Box flex="1" h="100%">
+        <Box flex="1" h="100%" visibleFrom='md'>
           <TreatmentPlanDetailSection />
         </Box>
       </Group>

--- a/frontend/src/app/(main)/validations/page.tsx
+++ b/frontend/src/app/(main)/validations/page.tsx
@@ -17,7 +17,7 @@ export default function ProcedureValidationPage() {
         </Box>
 
         {/* TODO: Colocar o DetailSection do Procedure */}
-        <Box flex="1" h="100%" visibleFrom='md'>
+        <Box flex="1" h="100%" visibleFrom="md">
           <TreatmentPlanDetailSection />
         </Box>
       </Group>

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -11,6 +11,13 @@ import { ModalsProvider } from '@mantine/modals';
 
 const theme = createTheme({
   fontFamily: 'Roboto, sans-serif',
+  breakpoints: {
+    xs: '36em',
+    sm: '48em',
+    md: '62em',
+    lg: '75em',
+    xl: '88em',
+  },
 });
 
 export default function Providers({

--- a/frontend/src/features/treatment-plans/treatment-plans-section.tsx
+++ b/frontend/src/features/treatment-plans/treatment-plans-section.tsx
@@ -16,6 +16,7 @@ import { modals } from '@mantine/modals';
 import { IconPlus } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useMediaQuery } from '@mantine/hooks';
 
 import TreatmentPlanCard from '@/shared/components/treatment-plan-card';
 import { TreatmentPlanShort } from '@/shared/models';
@@ -117,14 +118,21 @@ function getLastEmptyYear(
 }
 
 function TreatmentPlansContent({ data }: { data: TreatmentPlanShort[] }) {
+  const matches = useMediaQuery('(min-width: 56.25em)');
   const router = useRouter();
   const searchParams = useSearchParams();
   const active = searchParams.get('active');
 
-  function onTreatmentPlanSelect(treatmentPlanId: string) {
+  function onTreatmentPlanSelect(treatmentPlanId: string, patientId: string) {
     const newParams = new URLSearchParams(searchParams);
     newParams.set('active', treatmentPlanId);
-    router.push(`?${newParams.toString()}`, { scroll: false });
+
+    // Check if we're on mobile (below 'md' breakpoint)
+    if (matches) {
+      router.push(`/patients/${patientId}/treatments/${treatmentPlanId}`);
+    } else {
+      router.push(`?${newParams.toString()}`, { scroll: false });
+    }
   }
 
   if (data.length === 0) {
@@ -163,7 +171,7 @@ function TreatmentPlansContent({ data }: { data: TreatmentPlanShort[] }) {
                   key={tp.id}
                   treatmentPlan={tp}
                   selected={tp.id === active?.toString()}
-                  onSelect={onTreatmentPlanSelect}
+                  onSelect={() => onTreatmentPlanSelect(tp.id, tp.patient.id)}
                 />
               ))}
             </Stack>

--- a/frontend/src/features/treatment-plans/treatment-plans-section.tsx
+++ b/frontend/src/features/treatment-plans/treatment-plans-section.tsx
@@ -118,7 +118,7 @@ function getLastEmptyYear(
 }
 
 function TreatmentPlansContent({ data }: { data: TreatmentPlanShort[] }) {
-  const matches = useMediaQuery('(min-width: 56.25em)');
+  const matches = useMediaQuery('(max-width: 62em)');
   const router = useRouter();
   const searchParams = useSearchParams();
   const active = searchParams.get('active');

--- a/frontend/src/features/validations/validations-section.tsx
+++ b/frontend/src/features/validations/validations-section.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import {
   Badge,
   Card,
@@ -12,6 +13,7 @@ import {
 } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useMediaQuery } from '@mantine/hooks';
 
 import ProcedureCard from '@/shared/components/procedure-card';
 import TreatmentPlanCard from '@/shared/components/treatment-plan-card';
@@ -74,14 +76,22 @@ function isTreatmentPlan(r: ReviewableShort): r is TreatmentPlanShort {
 }
 
 function ValidationsContent({ data }: { data: ReviewableShort[] }) {
+  const matches = useMediaQuery('(min-width: 56.25em)');
   const router = useRouter();
   const searchParams = useSearchParams();
   const active = searchParams.get('active');
 
-  function onReviewableSelect(reviewableId: string) {
+  function onReviewableSelect(reviewableId: string, patientId: string) {
     const newParams = new URLSearchParams(searchParams);
     newParams.set('active', reviewableId);
-    router.push(`?${newParams.toString()}`, { scroll: false });
+
+    // Check if we're on mobile (below 'md' breakpoint)
+    // TODO: Depois checar se é treatment-plan ou procedure e mandar para rota correta
+    if (matches) {
+      router.push(`/patients/${patientId}/treatments/${reviewableId}`);
+    } else {
+      router.push(`?${newParams.toString()}`, { scroll: false });
+    }
   }
 
   if (data.length === 0) {
@@ -106,7 +116,7 @@ function ValidationsContent({ data }: { data: ReviewableShort[] }) {
               key={index}
               procedure={rev}
               selected={rev.id === active?.toString()}
-              onSelect={onReviewableSelect}
+              onSelect={() => onReviewableSelect(rev.id, rev.patient.id)}
               disableSession
             />
           );
@@ -117,7 +127,7 @@ function ValidationsContent({ data }: { data: ReviewableShort[] }) {
               key={index}
               treatmentPlan={rev}
               selected={rev.id === active?.toString()}
-              onSelect={onReviewableSelect}
+              onSelect={() => onReviewableSelect(rev.id, rev.patient.id)}
             />
           );
         }


### PR DESCRIPTION
## Resumo
<!-- Inclua um resumo da alteração -->
A PR melhora a experiência do usuário em dispositivos móveis, tornando as seções de detalhes do plano de tratamento e da validação responsivas ao tamanho da tela. Ela introduz renderização condicional e lógica de navegação com base no breakpoint do dispositivo, garantindo que, em dispositivos móveis, os usuários sejam direcionados diretamente para as páginas de detalhes, enquanto em desktops, as seções de detalhes permanecem visíveis na barra lateral.

## Task relacionada
<!-- Adicione link(s) para as tasks do Jira relacionadas a este PR -->
[PDS-134](https://rvaf.atlassian.net/browse/PDS-134)


[PDS-134]: https://rvaf.atlassian.net/browse/PDS-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ