### PR TITLE
fix(search): Remove search query da requisição por pacientes do spotlight

### DIFF
--- a/frontend/src/features/appshell/search.tsx
+++ b/frontend/src/features/appshell/search.tsx
@@ -71,9 +71,10 @@ export default function Search() {
 
 function SearchContent({ query }: { query: string }) {
   const router = useRouter();
+  // TODO: Adicionar search query, mas apenas com Debounce
   const { data, isLoading } = useQuery({
-    queryKey: ['patientsSearch', query],
-    queryFn: async () => await getAllPatients(query),
+    queryKey: ['patientsSearch'],
+    queryFn: async () => await getAllPatients(),
   });
 
   if (isLoading || data === undefined) {


### PR DESCRIPTION
Antes, uma nova requisição era feita a cada letra que o indivíduo digitava, pois não não implementei o debounce. O resultado:

<img width="1600" height="884" alt="image" src="https://github.com/user-attachments/assets/de3f8797-667f-4ce0-8d95-a94a0367e992" />

Corrigido:
<img width="1630" height="901" alt="image" src="https://github.com/user-attachments/assets/3ac7e82c-1e8c-4638-82cb-c6cbedd209a8" />
