### PR TITLE
hotfix: Adiciona migration faltante

### DIFF
--- a/server/src/main/resources/db/migration/V2__column_performed_at.sql
+++ b/server/src/main/resources/db/migration/V2__column_performed_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE procedures
+    ADD COLUMN performed_at TIMESTAMP WITHOUT TIME ZONE;


### PR DESCRIPTION
## Resumo
<!-- Inclua um resumo da alteração -->
- Adiciona migration para o campo `performedAt` da pr https://github.com/Odontolog/odontolog/pull/75. Não existiam migrations ainda.

## Informações adicionais
<!-- Adicione detalhes adicionais que você acha importante -->
<!-- Adicione um print quando possível -->

## Task relacionada
<!-- Adicione link(s) para as tasks do Jira relacionadas a este PR -->
